### PR TITLE
ci: add release github action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Exclude files from exporting
+.gitattributes export-ignore
+.gitignore export-ignore
+*.ps1  export-ignore
+/.vscode export-ignore
+/.github export-ignore
+/other  export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+on: push
+name: Release Factorio Mod
+jobs:
+  release-github:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@main
+      - name: Create Factorio mod package
+        id: package
+        uses: klaborda/factorio-mod-create-package@main
+      - name: Create GitHub release
+        uses: Roang-zero1/github-create-release-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_EXISTING: "true"
+          VERSION_REGEX: ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
+      - name: Upload GitHub artifacts
+        uses: Roang-zero1/github-upload-release-artifacts-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: dist/


### PR DESCRIPTION
Leverage github actions to create a release whenever a new tag is pushed.  When you click into the release, you can directly download the zip file from the assets.

**Note:** The tag version is checked against the version in `info.json` (they must match), so make sure they're synced!

`git tag 0.0.4 && git push origin --tags`

![ei_gh_action](https://user-images.githubusercontent.com/98995/210026070-4f72d552-884b-4f13-832c-b1fe36f2e98d.gif)
