### PR TITLE
Updating Entity Names in Induction Math

### DIFF
--- a/scripts/control/induction_matrix.lua
+++ b/scripts/control/induction_matrix.lua
@@ -729,7 +729,7 @@ function model.get_connected_solenoid_count(entity)
 
     end
 
-    if east_entity == nil and north == nil then
+    if east_entity == nil and north_entity == nil then
 
         if south_entity ~= nil and west_entity ~= nil then
             return 1.2
@@ -739,7 +739,7 @@ function model.get_connected_solenoid_count(entity)
 
     end
 
-    if east_entity == nil and south == nil then
+    if east_entity == nil and south_entity == nil then
 
         if north_entity ~= nil and west_entity ~= nil then
             return 1.2
@@ -749,7 +749,7 @@ function model.get_connected_solenoid_count(entity)
 
     end
 
-    if west_entity == nil and north == nil then
+    if west_entity == nil and north_entity == nil then
 
         if south_entity ~= nil and east_entity ~= nil then
             return 1.2
@@ -759,7 +759,7 @@ function model.get_connected_solenoid_count(entity)
 
     end
 
-    if west_entity == nil and south == nil then
+    if west_entity == nil and south_entity == nil then
 
         if north_entity ~= nil and east_entity ~= nil then
             return 1.2

--- a/scripts/control/induction_matrix.lua
+++ b/scripts/control/induction_matrix.lua
@@ -781,7 +781,7 @@ function model.buff_function(n)
     end
 
     if n <= 96 then
-        return 2 - 1/48 * n
+        return 2 - 1/48 * (n-48)
     end
 
     return 1
@@ -793,7 +793,7 @@ function model.get_max_connected_tiles(force)
     if not force then
         return 8*8
     end
-
+ 
     if force.technologies["ei_superior-induction-matrix"].researched then
         return 12*12
     end

--- a/scripts/control/induction_matrix.lua
+++ b/scripts/control/induction_matrix.lua
@@ -793,7 +793,7 @@ function model.get_max_connected_tiles(force)
     if not force then
         return 8*8
     end
- 
+
     if force.technologies["ei_superior-induction-matrix"].researched then
         return 12*12
     end


### PR DESCRIPTION
Looking through the induction matrix math and calculations, it's currently checking against north and south, rather than north_entity and south_entity. Quick PR to update that.