### PR TITLE
Fix several spelling and grammatical errors.

### DIFF
--- a/locale/en/lang_en.cfg
+++ b/locale/en/lang_en.cfg
@@ -889,7 +889,7 @@ cranes-and-belts=New belts and inserter cranes
 cranes-and-belts-text=Exotic Industries introduces a new tier of belts, called the [color=orange]neo logistic belt[/color] [item=ei_neo-belt] made from hightech materials with 90 items/s throughput. In addition new big inserters called [color=orange]cranes [/color] [item=ei_big-inserter] are added by the mod. They can be used to unload trains at high speeds or transfer items between chests/warehouses. 
 
 bots=More bots
-bots-text=If your playing with the Exotic Industries Bots mod you will also have access to specialised and superior robots as well as a new roboport.
+bots-text=If you're playing with the Exotic Industries Bots mod you will also have access to specialised and superior robots as well as a new roboport.
 
 
 new-mechanics=New gameplay mechanics
@@ -905,7 +905,7 @@ space-destinations=Space destinations
 space-destinations-text=The [color=orange]rocket silo[/color] [item=rocket-silo] can be used to send its cargo to different destinations. When it first gets unlocked in the computer age you will only be able to send satellites into [color=green]nauvis orbit[/color]. Depending on the type of sent satellite or rocket cargo you can then recieve data or other usefull launch products.
 
 space-destinations-2=Different destinations
-space-destinations-2-text=As you progress more and more different destinations in and away from your native solar system will become available. Depending on the distance to the selected destination you will need more or less rocket fuel. Additionally some destinations need to be uncovered first, either by sending a specialised [color=orange]exploration satellite[/color] [item=ei_exploration-satellite] or by chance when sending a rocket with normal cargo. Some new destiantions might be located in deep space, [color=purple]out of the solar system[/color]. Note that even when sending exploration satellites uncovering new destinations always depends on chance.  
+space-destinations-2-text=As you progress, various destinations in and away from your native solar system will become available. Depending on the distance to the selected destination you will need more or less rocket fuel. Additionally some destinations need to be uncovered first, either by sending a specialised [color=orange]exploration satellite[/color] [item=ei_exploration-satellite] or by chance when sending a rocket with normal cargo. Some new destiantions might be located in deep space, [color=purple]out of the solar system[/color]. Note that even when sending exploration satellites uncovering new destinations always depends on chance.  
 
 induction-matrix=Induction matrix
 induction-matrix-text=The [color=orange]induction matrix[/color] is a compound machine that can be used to store large amounts of energy. It can be used to store overhead power just like normal accumulators and then release it later on. Different tiers of matrix size can be unlocked by researching the corresponding technologies.

--- a/locale/en/lang_en.cfg
+++ b/locale/en/lang_en.cfg
@@ -322,8 +322,8 @@ ei_molten-lead=Molten lead
 ei_molten-gold=Molten gold
 ei_molten-steel=Molten steel
 ei_molten-neodym=Molten neodymium
-ei_heavy-destilate=Heavy oil destilate
-ei_medium-destilate=Medium oil destilate
+ei_heavy-destilate=Heavy oil distillate
+ei_medium-destilate=Medium oil distillate
 ei_residual-oil=Residual oil
 ei_benzol=Benzol
 ei_dirty-water=Dirty water
@@ -340,7 +340,7 @@ ei_nitric-acid-uranium-233=Uranium 233 fission products solution
 ei_nitric-acid-thorium-232=Thorium 232 fission products solution
 ei_nitric-acid-plutonium-239=Plutonium 239 fission products solution
 ei_kerosene=Kerosene
-ei_lube-destilate=Lubricant destilate
+ei_lube-destilate=Lubricant distillate
 ei_crystal-solution=Energy crystal solution
 ei_nitrogen-gas=Nitrogen gas
 ei_liquid-nitrogen=Liquid nitrogen
@@ -586,19 +586,19 @@ ei_module-base=The foundation of a module. Can be used to craft various modules.
 ei_photon-cavity=A cavity designed to store photons.
 ei_z-boson-cavity=A cavity designed to store z-bosons.
 ei_gluon-cavity=A cavity designed to store gluons.
-ei_destill-tower=A distill tower that requires [color=red]heat[/color] to function. Can seperate [color=orange]residual oil[/color] [fluid=ei_residual-oil] into its components.
-ei_advanced-destillation-tower=A distill tower that requires [color=yellow]electricity[/color] to function. Can seperate [color=orange]residual oil[/color] [fluid=ei_residual-oil] into its components.
+ei_destill-tower=A distillation tower that requires [color=red]heat[/color] to function. Can separate [color=orange]residual oil[/color] [fluid=ei_residual-oil] into its components.
+ei_advanced-destillation-tower=A distillation tower that requires [color=yellow]electricity[/color] to function. Can separate [color=orange]residual oil[/color] [fluid=ei_residual-oil] into its components.
 
-ei_space-data=Obtained by launiching a [color=blue]satellite[/color] [item=satellite] into [color=green]nauvis orbit[/color].
-ei_moon-fish=Obtained by launiching a [color=blue]raw fish[/color] [item=raw-fish] to the [color=green]moon[/color].
-ei_moon-rock=Obtained by launiching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to the [color=green]moon[/color].
-ei_mars_rock=Obtained by launiching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to [color=green]mars[/color].
-ei_sulf_rock=Obtained by launiching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to [color=green]sulf planet[/color].
-ei_uran-rock=Obtained by launiching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to [color=green]uran planet[/color].
-ei_exotic-rock=Obtained by launiching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to the [color=green]asteroid[/color].
-ei_sun-data=Obtained by launiching a [color=blue]observation satellite[/color] [item=ei_watch-satellite] into [color=green]sun orbit[/color].
-ei_gas-giant-data=Obtained by launiching a [color=blue]observation satellite[/color] [item=ei_watch-satellite] into [color=green]gas giant orbit[/color].
-ei_black-hole-data=Obtained by launiching a [color=blue]observation satellite[/color] [item=ei_watch-satellite] into [color=green]black hole orbit[/color].
+ei_space-data=Obtained by launching a [color=blue]satellite[/color] [item=satellite] into [color=green]nauvis orbit[/color].
+ei_moon-fish=Obtained by launching a [color=blue]raw fish[/color] [item=raw-fish] to the [color=green]moon[/color].
+ei_moon-rock=Obtained by launching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to the [color=green]moon[/color].
+ei_mars_rock=Obtained by launching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to [color=green]mars[/color].
+ei_sulf_rock=Obtained by launching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to [color=green]sulf planet[/color].
+ei_uran-rock=Obtained by launching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to [color=green]uran planet[/color].
+ei_exotic-rock=Obtained by launching a [color=blue]mining satellite[/color] [item=ei_mining-satellite] to the [color=green]asteroid[/color].
+ei_sun-data=Obtained by launching a [color=blue]observation satellite[/color] [item=ei_watch-satellite] into [color=green]sun orbit[/color].
+ei_gas-giant-data=Obtained by launching a [color=blue]observation satellite[/color] [item=ei_watch-satellite] into [color=green]gas giant orbit[/color].
+ei_black-hole-data=Obtained by launching a [color=blue]observation satellite[/color] [item=ei_watch-satellite] into [color=green]black hole orbit[/color].
 
 [fuel-category-name]
 ei_nuclear-fuel=Nuclear fission fuel
@@ -627,7 +627,7 @@ ei_mars-rock:centrifuging=Mars rock centrifuging
 ei_sulf-rock:centrifuging=Sulfuric planet rock centrifuging
 ei_uran-rock:centrifuging=Uran planet rock centrifuging
 ei_exotic-rock:centrifuging=Exotic rock centrifuging
-ei_exotic-matter=Exotic matter seperation
+ei_exotic-matter=Exotic matter separation
 ei_iron-extraction=Iron extraction
 ei_copper-extraction=Copper extraction
 ei_gold-extraction=Gold extraction
@@ -859,10 +859,10 @@ world-gen-related-text=This section contains information about the mod's world g
 
 
 resources=New resource system
-resources-text=Exotic Industries introduces a new resource system. Rather then only having ore patches, resources in this mod are seperated in certain categories.
+resources-text=Exotic Industries introduces a new resource system. Rather than only having ore patches, resources are separated into various categories.
 
 stone=Stone
-stone-text=Stone is the most common resource in the game. There are no patches where is spawns but instead stone can be minded from everywhere using a [color=orange]stone quarry[/color] [item=ei_stone-quarry][item=ei_electric-stone-quarry]. In addition to these quarries the player is capable of collecting stone by hand.
+stone-text=Stone is the most common resource in the game. There are no patches where it spawns, but instead stone can be mined from everywhere using a [color=orange]stone quarry[/color] [item=ei_stone-quarry][item=ei_electric-stone-quarry]. In addition to these quarries the player is capable of collecting stone by hand.
 
 surface-patches=Surface ore patches
 surface-patches-text=Surface ore patches can be found just as in vanilla factorio. However they only exist for iron and copper and will only yield [color=brown]poor ore fragments[/color] [item=ei_poor-iron-chunk][item=ei_poor-copper-chunk]. Smelting these fragments will always yield slag as a byproduct that you have to deal with.
@@ -873,14 +873,14 @@ veins-text=Ore veins are only accessible later in the game by using [color=orang
 artifacts=Alien artifacts
 artifacts-text=Some artifacts have been left behind by an ancient civilization that was able to harness the power of exotic matter. You can find their artifacts scattered across the world. Some of them might even still work.
 
-actifacts-text-2=But be carefull they might be untouched for some reason...
+actifacts-text-2=But be careful, they might be untouched for some reason...
 
 
 new-logistics=New logistics
 new-logistics-text=Exotic Industries also introduces some new logistics features. These features are divided into several subcategories. You can find them in the menu on the left.
 
 train-progression=Train progression
-train-progression-text=Trains are available from early on in the steam age. At first you can only built a basic [color=orange]steam locomotive[/color] [item=ei_steam-basic-locomotive], allowing item but no fluid transport. With the improved [color=orange]advanced steam locomotive[/color] [item=ei_steam-advanced-locomotive] you can transport fluids as well. Both of these trains are fueled by burnable fuel, such as coal. However later on [color=brown]diesel fuel[/color] [item=ei_diesel-fuel-unit] is needed to power the better [color=orange] diesel locomotives[/color] [item=locomotive].
+train-progression-text=Trains are available from early on in the steam age. At first you can only build a basic [color=orange]steam locomotive[/color] [item=ei_steam-basic-locomotive], allowing item but no fluid transport. With the improved [color=orange]advanced steam locomotive[/color] [item=ei_steam-advanced-locomotive] you can transport fluids as well. Both of these trains are fueled by burnable fuel, such as coal. However later on [color=brown]diesel fuel[/color] [item=ei_diesel-fuel-unit] is needed to power the better [color=orange] diesel locomotives[/color] [item=locomotive].
 
 spidertron=Spidertron changes
 spidertron-text=Compared to vanilla spidertron is available early in the computer age. However fuel is needed to power the vehicle. Burnable fuels are a solid choice in the beginning, but later on nuclear or fusion based fuels yield good speed and acceleration bonuses onto the spidertron. In addition mods like [color=green]Spidertron Patrols[/color] and [color=green]Constructron-Continued[/color] have got special integration folling the spidertron changes.


### PR DESCRIPTION
Unfortunately, the misspelled "destilate" is used in the internal names themselves, and cannot be changed without impacting code and existing users, so only the user-visible descriptions are fixed.