### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,48 @@
 This is the main mod of the new EI mod series.
 For more info on development and planned features see [**mod_progression**](https://github.com/PreLeyZero/248k-2/blob/main/README.md).
 
-# Running the development build of Exotic Industries (EI)
 
-## Downloads for EI core mods:
+# Running Exotic Industries (EI)
 
-- >Download the EI repo as a zip file by clicking this [link](https://github.com/PreLeyZero/exotic-industries/releases/).
+## Running the released version using the in game mod manager
+
+- >For the full developer recommended set of mods install [Exotic Industries: Official Modpack](https://mods.factorio.com/mod/exotic-industries-modpack).
+
+- >For just the EI core mods install [Exotic Industries](https://mods.factorio.com/mod/exotic-industries).
 
 
-- >Download the EI graphics repo as a zip file by clicking this [link](https://github.com/PreLeyZero/exotic-industries-graphics/releases).
+## Running the latest development build
 
-## Copy the mods into the factorio mods folder:
+* Download the EI core mods:
 
-1. Find the `mods` folder for factorio for your given OS [[ref](https://wiki.factorio.com/index.php?title=Application_directory)]
-2. Copy the zip files from above and place them in the `mods` folder.
+    - >Download the EI repo as a zip file by clicking this [link](https://github.com/PreLeyZero/exotic-industries/releases/).
 
-## Additional mods for EI:
+    - >Download the EI graphics repo as a zip file by clicking this [link](https://github.com/PreLeyZero/exotic-industries-graphics/releases/).
+
+* Copy the mods into the factorio mods folder:
+
+    1. Find the `mods` folder for factorio for your given OS [[ref](https://wiki.factorio.com/index.php?title=Application_directory)]
+
+    2. Copy the zip files from above and place them in the `mods` folder.
+
+
+## Running the in progress development version
+
+*Warning:* This method is not recommended unless you are actively working on developing the mod. It will not auto-update and will require you to manually use git to update the mod.
+
+- Into your `mods` folder clone the main EI repo and the EI graphics repo
+    ```
+    git clone https://github.com/PreLeyZero/exotic-industries.git exotic-industries
+    git clone https://github.com/PreLeyZero/exotic-industries-graphics.git exotic-industries-graphics
+    ```
+
+
+# Additional mods for EI:
 
 - >Exotic Industries: [Loaders](https://mods.factorio.com/mod/exotic-industries-loaders)
 
 - >Exotic Industries: [Containers](https://mods.factorio.com/mod/exotic-industries-containers)
+
 
 #
 

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ For more info on development and planned features see [**mod_progression**](http
 
 #
 
-Make sure to give some feedback to help develop and balance the Exotic Industries mod series.
+Be sure to give some feedback to help develop and balance the Exotic Industries mod series.  You can join the conversation on [Discord](https://discord.gg/DhPxNAJ3nt).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Exotic Industries mod
 
-This is the main mod of the new EI mod series.
-For more info on development and planned features see [**mod_progression**](https://github.com/PreLeyZero/248k-2/blob/main/README.md).
+This is the main mod of the new Exotic Industries mod series.
 
 
 # Running Exotic Industries (EI)


### PR DESCRIPTION
A few updates to the readme.

* Add instructions to install EI from the mod manager and links to the mod portal.
* Add instructions for installing directly with git.
* Add discord link.
* Removed the now dead link to the early EI planning document.
* Some minor reformatting

Now that the mod has been released to the mod portal it seems like github releases are no longer being done. They do seem unnecessary at this point. If that is actually the plan going forward then the whole section on installing them should just be removed.