### PR TITLE
feat(induction-matirx): updates the induction matrix to have a live energy display

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 0.5.0
 Date: XX.XX.2023
   Features:
     - alien update
+    - induction matrixes now show current stored capacity (PR #29)
   Changes:
     - alien update balance changes
   Bugfixes:


### PR DESCRIPTION
The induction matrix now shows a display of its current energy capacity compared to its maximum energy capacity.

The readout updates is only processed every 10 ticks and short circuits if no GUI is open, so I think this should be performant enough.

![image](https://github.com/PreLeyZero/exotic-industries/assets/38093621/8b7267d2-b498-4400-93fa-be90d699c889)
![image](https://github.com/PreLeyZero/exotic-industries/assets/38093621/4a9dceb6-30d7-42e7-89aa-dc374abd7d05)

Resolves https://discord.com/channels/829471678080745522/829473119038079066/1101277577743704104

