### PR TITLE
Add crafting-with-fluid to steam assembler

### DIFF
--- a/prototypes/steam_age/steam-assembler.lua
+++ b/prototypes/steam_age/steam-assembler.lua
@@ -74,7 +74,7 @@ data:extend({
         collision_box = data.raw["assembling-machine"]["assembling-machine-1"].collision_box,
         selection_box = data.raw["assembling-machine"]["assembling-machine-1"].selection_box,
         map_color = ei_data.colors.assembler,
-        crafting_categories = {"ei_steam-assembler", "crafting"},
+        crafting_categories = {"ei_steam-assembler", "crafting", "crafting-with-fluid"},
         crafting_speed = 0.5,
         energy_source = {
             type = "fluid",


### PR DESCRIPTION
- Allows fast replacing of the steam assembler with mk2/mk3 assembler which can handle fluid inputs in the same orientation as the steam assembler