### PR TITLE
Set whitelists for the repair selection tools.

### DIFF
--- a/lib/data.lua
+++ b/lib/data.lua
@@ -938,6 +938,15 @@ ei_data.repair_tools = {
     }
 }
 
+-- only used during data phase
+function ei_data.repair_tool_entity_filter(name)
+  local entity_filter = {}
+  for ent, _ in pairs(ei_data.repair_tools[name].targets) do
+    table.insert(entity_filter, ent)
+  end
+  return entity_filter
+end
+
 --====================================================================================================
 --Knowledge Scanner
 --====================================================================================================

--- a/prototypes/alien_structures/alien-beacon.lua
+++ b/prototypes/alien_structures/alien-beacon.lua
@@ -172,6 +172,8 @@ data:extend({
         alt_selection_color = {r=0, g=1, b=0, a=0.5 },
         alt_selection_cursor_box_type = "entity",
         alt_selection_mode = {"any-entity"},
+        entity_filter_mode = "whitelist",
+        entity_filters = ei_data.repair_tool_entity_filter("ei_alien-beacon-repair"),
         subgroup = "ei_repairs",
         order = "a-c",
     },

--- a/prototypes/alien_structures/crystal-accumulator.lua
+++ b/prototypes/alien_structures/crystal-accumulator.lua
@@ -26,6 +26,8 @@ data:extend({
         alt_selection_color = {r=0, g=1, b=0, a=0.5 },
         alt_selection_cursor_box_type = "entity",
         alt_selection_mode = {"any-entity"},
+        entity_filter_mode = "whitelist",
+        entity_filters = ei_data.repair_tool_entity_filter("ei_crystal-accumulator-repair"),
         subgroup = "ei_repairs",
         order = "a-a",
     },

--- a/prototypes/alien_structures/farstation.lua
+++ b/prototypes/alien_structures/farstation.lua
@@ -225,6 +225,8 @@ data:extend({
         alt_selection_color = {r=0, g=1, b=0, a=0.5 },
         alt_selection_cursor_box_type = "entity",
         alt_selection_mode = {"any-entity"},
+        entity_filter_mode = "whitelist",
+        entity_filters = ei_data.repair_tool_entity_filter("ei_farstation-repair"),
         subgroup = "ei_repairs",
         order = "a-b",
     },


### PR DESCRIPTION
Use the info from ie_data.repair_tools.

The selection tools will only highlight what they can fix.